### PR TITLE
Add keywords

### DIFF
--- a/data/org.gnome.gitlab.dqpb.GMetronome.desktop.in.in
+++ b/data/org.gnome.gitlab.dqpb.GMetronome.desktop.in.in
@@ -9,3 +9,5 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Audio;AudioVideo;Music;GTK;
+# Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+Keywords=Bar;Beats;BPM;Measure;Metronome;Minute;Practice;Rhythm;Tap;Tempo;Time;


### PR DESCRIPTION
This will make it easier to e.g. search for the app in the GNOME Shell overview (especially frustrating that the app doesn’t show up currently if you type “metronome”). I used the list from [Metronome](https://gitlab.gnome.org/World/metronome) and amended it.
(I also opened [an MR](https://gitlab.gnome.org/World/metronome/-/merge_requests/42) there to add the new ones I threw in here, except for “Metronome” which is not needed for them as it’s the name of the app.)